### PR TITLE
Add medialocal to the run arguments for indexer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ if (CONDUCTOR_XMX == 'null' || CONDUCTOR_XMX == null || CONDUCTOR_XMX == "") {
 }
 
 if (C_ARGS == 'null' || C_ARGS == null || C_ARGS == "") {
-    C_ARGS = 'local postgres dl4j'
+    C_ARGS = 'local postgres medialocal dl4j'
 }
 
 if (PARALLEL == 'null' || PARALLEL == null || PARALLEL == "") {

--- a/src/main/resources/auth0.yaml
+++ b/src/main/resources/auth0.yaml
@@ -1,9 +1,20 @@
 domain: "openlattice.auth0.com"
-issuer: "https://openlattice.auth0.com/"
-clientId: "KTzgyxs6KBcJHB872eSMe2cpTHzhxS99"
-clientSecret: "tjAwhBit0deVUor3lcd7YRlHRc_4FJwv_fcLp_ozO2-D2Lh38066IUoGPL4zx1vP"
-securedRoute: "NOT_USED"
-authorityStrategy: "ROLES"
-signingAlgorithm: "HS256"
-base64EncodedSecret: false
-token: "lol"
+clientId: "kHRUw59T1ikOV67P2BXrYLRtzADRZ0Os"
+clientSecret: "g1ireyiyiHvnCm1uKB040YxIjTQ3d7ISOy_dcUTGONUPIGFTIV4bEI5p8l_uF5lD"
+managementApiUrl: "https://openlattice.auth0.com/api/v2/"
+configurations:
+  - issuer: "https://openlattice.auth0.com/"
+    audience: "KTzgyxs6KBcJHB872eSMe2cpTHzhxS99"
+    secret: "ignored"
+    base64EncodedSecret: false
+    signingAlgorithm: "RS256"
+  - issuer: "https://openlattice.auth0.com/"
+    audience: "KTzgyxs6KBcJHB872eSMe2cpTHzhxS99"
+    secret: "tjAwhBit0deVUor3lcd7YRlHRc_4FJwv_fcLp_ozO2-D2Lh38066IUoGPL4zx1vP"
+    base64EncodedSecret: false
+    signingAlgorithm: "HS256"
+  - issuer: "https://openlattice.auth0.com/"
+    audience: "https://tests.openlattice.com"
+    secret: "MK4CrccqOqI6WVkOiSJX6n2h3MLgGri0"
+    base64EncodedSecret: false
+    signingAlgorithm: "HS256"


### PR DESCRIPTION
This PR:
- Adds `medialocal` argument to the build.gradle run arguments for indexer as some form of this command is necessary to run indexer locally