### PR TITLE
add medialocal for running locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ if (CONDUCTOR_XMX == 'null' || CONDUCTOR_XMX == null || CONDUCTOR_XMX == "") {
 }
 
 if (C_ARGS == 'null' || C_ARGS == null || C_ARGS == "") {
-    C_ARGS = 'local postgres dl4j'
+    C_ARGS = 'local postgres medialocal dl4j'
 }
 
 if (PARALLEL == 'null' || PARALLEL == null || PARALLEL == "") {


### PR DESCRIPTION
This PR:
- Adds `medialocal` argument to the build.gradle run arguments for indexer as some form of this command is necessary to run indexer locally