### PR TITLE
Feature/lattice 2416 tables as metadata columns as data

### DIFF
--- a/src/main/kotlin/com/openlattice/BackgroundExternalDatabaseSyncingService.kt
+++ b/src/main/kotlin/com/openlattice/BackgroundExternalDatabaseSyncingService.kt
@@ -173,14 +173,7 @@ class BackgroundExternalDatabaseSyncingService(
     ): UUID {
         val newTableId = edms.createOrganizationExternalDatabaseTable(orgId, table)
         currentTableIds.add(newTableId)
-
-        //add table-level permissions
-        val acls = edms.syncPermissions(dbName, orgOwnerIds, orgId, newTableId, table.name, Optional.empty(), Optional.empty())
-
-        //create audit entity set and audit permissions
         ares.createAuditEntitySetForExternalDBTable(table)
-        val events = createAuditableEvents(acls, AuditEventType.ADD_PERMISSION)
-        auditingManager.recordEvents(events)
         return newTableId
     }
 


### PR DESCRIPTION
This PR addresses the need to be able to view atlas table metadata without being able to see table data. We will now only grant postgres privileges on columns and not on entire tables. This will enable us to
-Use the OrgExternalDbTable object for permissioning table metadata
-Use the OrgExternalDbColumn object for permissioning table data on a column by column basis.

Here we remove syncing and auditing of table permissions, as postgres privileges on tables no longer map to ol permissions